### PR TITLE
[add] working-with-server guide

### DIFF
--- a/docs/api/config/image-upload-url.md
+++ b/docs/api/config/image-upload-url.md
@@ -51,6 +51,6 @@ new richtext.Richtext("#root", {
 
 **Change log:** The property was added in v2.0. Starting with v2.1, the property is optional: when omitted, images are inserted inline as base64 data URLs.
 
-**Related articles:** [Configuration](guides/configuration.md)
+**Related articles:** [Configuration](guides/configuration.md), [Working with the server](guides/working_with_server.md)
 
 **Related sample:** [RichText. Initialization](https://snippet.dhtmlx.com/t55alxiy?tag=richtext)

--- a/docs/api/config/image-upload-url.md
+++ b/docs/api/config/image-upload-url.md
@@ -28,6 +28,6 @@ new richtext.Richtext("#root", {
 
 **Change log:** The property was added in v2.0
 
-**Related articles:** [Configuration](guides/configuration.md)
+**Related articles:** [Configuration](guides/configuration.md), [Working with the server](guides/working_with_server.md)
 
 **Related sample:** [RichText. Initialization](https://snippet.dhtmlx.com/t55alxiy?tag=richtext)

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -249,6 +249,8 @@ new richtext.Richtext("#root", {
 });
 ~~~
 
+See [Working with the server](guides/working_with_server.md) for the request/response contract the upload endpoint must implement and notes on what happens when no URL is configured.
+
 ## Configure default styles
 
 Use the [`defaultStyles`](api/config/default-styles.md) property to set default styles per block type.

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -265,11 +265,13 @@ new richtext.Richtext("#root", {
 });
 ~~~
 
-Inline images larger than 1024×800 are proportionally downscaled to fit within these limits.
+Inline images larger than 1024×800 are displayed at a reduced size (the `width`/`height` attributes are capped to fit within these limits), but the embedded bytes are the original, full-resolution file — the client does not downscale or re-encode it.
 
 :::note
 Inline (base64) images are not preserved by the built-in DOCX / PDF [export](api/events/export.md). If you rely on export, supply an `imageUploadUrl` so that images reference an external location.
 :::
+
+See [Working with the server](guides/working_with_server.md) for the full request/response contract the upload endpoint must implement and a closer look at the inline-image fallback.
 
 ## Configure default styles
 

--- a/docs/guides/working_with_server.md
+++ b/docs/guides/working_with_server.md
@@ -1,0 +1,118 @@
+---
+sidebar_label: Working with the server
+title: Working with the server
+description: Learn how RichText communicates with a backend for image uploads, including the request/response contract and how to plug in your own server. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX RichText.
+---
+
+# Working with the server
+
+RichText runs entirely in the browser and does not need a backend for editing or saving content. Your application is free to persist the content of the editor wherever it wants. The one feature that benefits from a server is **image upload**: when a user inserts an image into the document, RichText can either embed the file inline in the content or post it to an HTTP endpoint and store a link to it.
+
+This guide explains:
+
+- what happens by default when no upload server is configured,
+- the exact HTTP contract the server has to implement,
+- how the URL returned by the server is used afterwards,
+- how to try the feature against the demo backend.
+
+## Default behavior: inline images
+
+If you do not set the [`imageUploadUrl`](api/config/image-upload-url.md) property, RichText falls back to inline images. When the user inserts an image, the file is read in the browser, downscaled to fit a 1024×800 box, encoded as a `data:image/...;base64,...` URL, and written directly into the editor content as the `src` of the `<img>` element.
+
+This works without any backend and is handy for quick demos, but it has clear limitations:
+
+- the encoded image bytes live inside the document, so the saved HTML grows with every image;
+- the same image used in two documents is stored twice;
+- the image bytes live inside the document HTML rather than as a separate resource, so they can't be served from a CDN, deduplicated across documents, or post-processed (resized, re-encoded, scanned) on the server.
+
+## Writing your own server
+
+In production apps, point RichText at a server with [`imageUploadUrl`](api/config/image-upload-url.md):
+
+~~~jsx {2}
+new richtext.Richtext("#root", {
+    imageUploadUrl: "https://example.com/upload"
+    // other configuration properties
+});
+~~~
+
+A minimal upload endpoint needs to:
+
+1. Accept a `multipart/form-data` POST with a file field named `upload`.
+2. Validate the file (allowed types, maximum size).
+3. Store the file somewhere the user's browser can fetch (a local disk served over HTTP, S3, a CDN, etc).
+4. Optionally resize or otherwise process the image.
+5. Respond with a JSON object containing `status: "server"`, `value` set to the public URL of the stored file, and the image's `width` and `height` in pixels.
+
+Anything beyond that is up to you and invisible to RichText.
+
+### What the client sends
+
+When [`imageUploadUrl`](api/config/image-upload-url.md) is set, RichText posts the selected file directly to that URL, it does not append `/images` or any other path, so the URL you pass is the full POST target.
+
+The request uses standard HTML form upload:
+
+- **Method:** `POST`
+- **Content-Type:** `multipart/form-data`
+- **Body:** one file field named `upload`
+
+### What the client expects back
+
+The server must reply with a JSON object. RichText reads the following fields:
+
+| Field    | Type    | Meaning                                                                 |
+| -------- | ------- | ----------------------------------------------------------------------- |
+| `status` | string  | Result marker. Use `"server"` for success. Any other value (for example `"error"`) is treated as failure and the image is not inserted. |
+| `value`  | string  | URL of the stored image. RichText writes this string verbatim into the document as the `src` of the inserted `<img>`. |
+| `width`  | integer | Width used to size the inserted image, in pixels.                       |
+| `height` | integer | Height used to size the inserted image, in pixels.                      |
+
+A successful response:
+
+~~~json
+{
+    "status": "server",
+    "value": "https://cdn.example.com/uploads/abc123.png",
+    "width": 320,
+    "height": 207
+}
+~~~
+
+A failed upload:
+
+~~~json
+{
+    "status": "error"
+}
+~~~
+
+### Serving the uploaded image
+
+The `value` URL is the only thing that connects the upload step to everything that happens later. RichText puts it straight into the document, so any client that later opens the saved content - the editor itself, an export, a published page - will fetch the image from that URL with a plain `GET`.
+
+That means:
+
+- the URL must be reachable from the user's browser, which usually means it has to be **absolute**;
+- the host can be different from the upload endpoint - for example, you can accept uploads on your own server and return a CDN or object-storage URL;
+- if the image host is on a different origin, make sure it allows the page to load the image (CORS or simply public read access);
+- the server must keep that URL working for as long as documents reference it; RichText does not cache or copy the bytes.
+
+The URL layout itself is **not** part of the contract. As long as the browser can `GET` the URL and receive image bytes, the path, the query string, or even the scheme are entirely up to the backend.
+
+### Try it against the demo server
+
+A working backend that implements this contract is available for trying out the feature:
+
+~~~jsx
+new richtext.Richtext("#root", {
+    imageUploadUrl: "https://docs.dhtmlx.com/richtext-backend/images"
+    // other configuration properties
+});
+~~~
+
+The demo server resizes large images, stores them on disk, and returns URLs it serves itself. It is intended for evaluation and demos only. Do not point production editors at it.
+
+**Related articles:**
+
+- [Configuration](guides/configuration.md)
+- [`imageUploadUrl`](api/config/image-upload-url.md)

--- a/docs/guides/working_with_server.md
+++ b/docs/guides/working_with_server.md
@@ -17,13 +17,13 @@ This guide explains:
 
 ## Default behavior: inline images
 
-If you do not set the [`imageUploadUrl`](api/config/image-upload-url.md) property, RichText falls back to inline images. When the user inserts an image, RichText reads the file in the browser, encodes the original file as a `data:image/...;base64,...` URL, and writes it directly into the editor content as the `src` of the `<img>` element. The displayed size is constrained to fit within a 1024×800 box through the `width`/`height` attributes, but the embedded bytes are the original, full-resolution file — the client does not downscale or re-encode it.
+If you do not set the [`imageUploadUrl`](api/config/image-upload-url.md) property, RichText falls back to inline images. When the user inserts an image, RichText reads the file in the browser, encodes the original file as a `data:image/...;base64,...` URL, and writes it directly into the editor content as the `src` of the `<img>` element. RichText constrains the displayed size to fit within a 1024×800 box through the `width`/`height` attributes, but the embedded bytes are the original, full-resolution file — the client does not downscale or re-encode it.
 
 This works without any backend and is handy for quick demos, but it has clear limitations:
 
-- the encoded image bytes live inside the document, so the saved HTML grows with every image
-- the same image used in two documents is stored twice
-- the image bytes live inside the document HTML rather than as a separate resource, so they can't be served from a CDN, deduplicated across documents, or post-processed (resized, re-encoded, scanned) on the server
+- the encoded bytes live inside the document, so the saved HTML grows with every image
+- the same image in two documents is stored twice — there is no shared resource to deduplicate
+- because the bytes are not a separate resource, the server cannot serve them from a CDN or post-process them (resize, re-encode, scan)
 
 ## Write your own server
 
@@ -40,7 +40,7 @@ A minimal upload endpoint needs to:
 
 1. Accept a `multipart/form-data` POST with a file field named `upload`.
 2. Validate the file (allowed types, maximum size).
-3. Store the file somewhere the user's browser can fetch (a local disk served over HTTP, S3, a CDN, etc).
+3. Store the file somewhere the user's browser can fetch (a local disk served over HTTP, S3, a CDN, etc.).
 4. Optionally resize or otherwise process the image.
 5. Respond with a JSON object that contains `status: "server"`, `value` set to the public URL of the stored file, and the image's `width` and `height` in pixels.
 
@@ -60,7 +60,7 @@ The server must reply with a JSON object. RichText reads the following fields:
 
 | Field    | Type    | Meaning                                                                 |
 | -------- | ------- | ----------------------------------------------------------------------- |
-| `status` | string  | Result marker. A successful upload must return `"server"`; the success contract relies on this value. Any other value (for example `"error"`) signals a failed upload on the server side. |
+| `status` | string  | Result marker. A successful upload must return `"server"`. Any other value (for example `"error"`) is treated as a failed upload, and the image is not inserted. |
 | `value`  | string  | URL of the stored image. RichText writes this string verbatim into the document as the `src` of the inserted `<img>`. |
 | `width`  | integer | Width used to size the inserted image, in pixels.                       |
 | `height` | integer | Height used to size the inserted image, in pixels.                      |
@@ -90,7 +90,7 @@ A failed upload returns any status other than `"server"`:
 
 ### Serve the uploaded image
 
-The `value` URL is the only thing that connects the upload step to everything that happens later. RichText puts the URL straight into the document, so any client that later opens the saved content (the editor itself, an export, a published page) fetches the image from that URL with a plain `GET`.
+The `value` URL is the only link between the upload and every later read of the document. RichText puts the URL straight into the document, so any client that opens the saved content (the editor itself, an export, a published page) fetches the image from that URL with a plain `GET`.
 
 That means:
 

--- a/docs/guides/working_with_server.md
+++ b/docs/guides/working_with_server.md
@@ -10,22 +10,22 @@ RichText runs entirely in the browser and does not need a backend for editing or
 
 This guide explains:
 
-- what happens by default when no upload server is configured,
-- the exact HTTP contract the server has to implement,
-- how the URL returned by the server is used afterwards,
-- how to try the feature against the demo backend.
+- what happens by default when no upload server is configured
+- the exact HTTP contract the server has to implement
+- how RichText uses the URL returned by the server
+- how to try the feature against the demo backend
 
 ## Default behavior: inline images
 
-If you do not set the [`imageUploadUrl`](api/config/image-upload-url.md) property, RichText falls back to inline images. When the user inserts an image, the file is read in the browser, downscaled to fit a 1024×800 box, encoded as a `data:image/...;base64,...` URL, and written directly into the editor content as the `src` of the `<img>` element.
+If you do not set the [`imageUploadUrl`](api/config/image-upload-url.md) property, RichText falls back to inline images. When the user inserts an image, RichText reads the file in the browser, downscales it to fit a 1024×800 box, encodes it as a `data:image/...;base64,...` URL, and writes it directly into the editor content as the `src` of the `<img>` element.
 
 This works without any backend and is handy for quick demos, but it has clear limitations:
 
-- the encoded image bytes live inside the document, so the saved HTML grows with every image;
-- the same image used in two documents is stored twice;
-- the image bytes live inside the document HTML rather than as a separate resource, so they can't be served from a CDN, deduplicated across documents, or post-processed (resized, re-encoded, scanned) on the server.
+- the encoded image bytes live inside the document, so the saved HTML grows with every image
+- the same image used in two documents is stored twice
+- the image bytes live inside the document HTML rather than as a separate resource, so they can't be served from a CDN, deduplicated across documents, or post-processed (resized, re-encoded, scanned) on the server
 
-## Writing your own server
+## Write your own server
 
 In production apps, point RichText at a server with [`imageUploadUrl`](api/config/image-upload-url.md):
 
@@ -42,13 +42,11 @@ A minimal upload endpoint needs to:
 2. Validate the file (allowed types, maximum size).
 3. Store the file somewhere the user's browser can fetch (a local disk served over HTTP, S3, a CDN, etc).
 4. Optionally resize or otherwise process the image.
-5. Respond with a JSON object containing `status: "server"`, `value` set to the public URL of the stored file, and the image's `width` and `height` in pixels.
-
-Anything beyond that is up to you and invisible to RichText.
+5. Respond with a JSON object that contains `status: "server"`, `value` set to the public URL of the stored file, and the image's `width` and `height` in pixels.
 
 ### What the client sends
 
-When [`imageUploadUrl`](api/config/image-upload-url.md) is set, RichText posts the selected file directly to that URL, it does not append `/images` or any other path, so the URL you pass is the full POST target.
+When [`imageUploadUrl`](api/config/image-upload-url.md) is set, RichText posts the selected file directly to that URL (it does not append `/images` or any other path), so the URL you pass is the full POST target.
 
 The request uses standard HTML form upload:
 
@@ -67,7 +65,9 @@ The server must reply with a JSON object. RichText reads the following fields:
 | `width`  | integer | Width used to size the inserted image, in pixels.                       |
 | `height` | integer | Height used to size the inserted image, in pixels.                      |
 
-A successful response:
+#### Successful response
+
+A successful upload returns the stored image URL and its dimensions:
 
 ~~~json
 {
@@ -78,7 +78,9 @@ A successful response:
 }
 ~~~
 
-A failed upload:
+#### Failed upload
+
+A failed upload returns any status other than `"server"`:
 
 ~~~json
 {
@@ -86,22 +88,22 @@ A failed upload:
 }
 ~~~
 
-### Serving the uploaded image
+### Serve the uploaded image
 
-The `value` URL is the only thing that connects the upload step to everything that happens later. RichText puts it straight into the document, so any client that later opens the saved content - the editor itself, an export, a published page - will fetch the image from that URL with a plain `GET`.
+The `value` URL is the only thing that connects the upload step to everything that happens later. RichText puts the URL straight into the document, so any client that later opens the saved content (the editor itself, an export, a published page) fetches the image from that URL with a plain `GET`.
 
 That means:
 
-- the URL must be reachable from the user's browser, which usually means it has to be **absolute**;
-- the host can be different from the upload endpoint - for example, you can accept uploads on your own server and return a CDN or object-storage URL;
-- if the image host is on a different origin, make sure it allows the page to load the image (CORS or simply public read access);
-- the server must keep that URL working for as long as documents reference it; RichText does not cache or copy the bytes.
+- the URL must be reachable from the user's browser, which usually means it has to be **absolute**
+- the host can be different from the upload endpoint (for example, you can accept uploads on your own server and return a CDN or object-storage URL)
+- if the image host is on a different origin, make sure it allows the page to load the image (CORS or simply public read access)
+- the server must keep that URL working for as long as documents reference it; RichText does not cache or copy the bytes
 
-The URL layout itself is **not** part of the contract. As long as the browser can `GET` the URL and receive image bytes, the path, the query string, or even the scheme are entirely up to the backend.
+The URL layout itself is **not** part of the contract. As long as the browser can `GET` the URL and receive image bytes, the path, the query string, and even the scheme are entirely up to the backend.
 
 ### Try it against the demo server
 
-A working backend that implements this contract is available for trying out the feature:
+A working backend that implements this contract is available to test the feature:
 
 ~~~jsx
 new richtext.Richtext("#root", {

--- a/docs/guides/working_with_server.md
+++ b/docs/guides/working_with_server.md
@@ -24,6 +24,7 @@ This works without any backend and is handy for quick demos, but it has clear li
 - the encoded bytes live inside the document, so the saved HTML grows with every image
 - the same image in two documents is stored twice — there is no shared resource to deduplicate
 - because the bytes are not a separate resource, the server cannot serve them from a CDN or post-process them (resize, re-encode, scan)
+- inline images are not preserved by the built-in DOCX / PDF [export](api/events/export.md) — if you rely on export, configure an upload server so images reference an external URL
 
 ## Write your own server
 
@@ -60,7 +61,7 @@ The server must reply with a JSON object. RichText reads the following fields:
 
 | Field    | Type    | Meaning                                                                 |
 | -------- | ------- | ----------------------------------------------------------------------- |
-| `status` | string  | Result marker. A successful upload must return `"server"`. Any other value (for example `"error"`) is treated as a failed upload, and the image is not inserted. |
+| `status` | string  | Success marker — return `"server"` for a successful upload. The uploader uses this field to tell a completed upload from a failed one; any other value (for example `"error"`) marks the upload as failed. The inserted image itself is built from `value`, `width`, and `height`. |
 | `value`  | string  | URL of the stored image. RichText writes this string verbatim into the document as the `src` of the inserted `<img>`. |
 | `width`  | integer | Width used to size the inserted image, in pixels.                       |
 | `height` | integer | Height used to size the inserted image, in pixels.                      |

--- a/docs/guides/working_with_server.md
+++ b/docs/guides/working_with_server.md
@@ -17,7 +17,7 @@ This guide explains:
 
 ## Default behavior: inline images
 
-If you do not set the [`imageUploadUrl`](api/config/image-upload-url.md) property, RichText falls back to inline images. When the user inserts an image, RichText reads the file in the browser, downscales it to fit a 1024×800 box, encodes it as a `data:image/...;base64,...` URL, and writes it directly into the editor content as the `src` of the `<img>` element.
+If you do not set the [`imageUploadUrl`](api/config/image-upload-url.md) property, RichText falls back to inline images. When the user inserts an image, RichText reads the file in the browser, encodes the original file as a `data:image/...;base64,...` URL, and writes it directly into the editor content as the `src` of the `<img>` element. The displayed size is constrained to fit within a 1024×800 box through the `width`/`height` attributes, but the embedded bytes are the original, full-resolution file — the client does not downscale or re-encode it.
 
 This works without any backend and is handy for quick demos, but it has clear limitations:
 
@@ -60,7 +60,7 @@ The server must reply with a JSON object. RichText reads the following fields:
 
 | Field    | Type    | Meaning                                                                 |
 | -------- | ------- | ----------------------------------------------------------------------- |
-| `status` | string  | Result marker. Use `"server"` for success. Any other value (for example `"error"`) is treated as failure and the image is not inserted. |
+| `status` | string  | Result marker. A successful upload must return `"server"`; the success contract relies on this value. Any other value (for example `"error"`) signals a failed upload on the server side. |
 | `value`  | string  | URL of the stored image. RichText writes this string verbatim into the document as the `src` of the inserted `<img>`. |
 | `width`  | integer | Width used to size the inserted image, in pixels.                       |
 | `height` | integer | Height used to size the inserted image, in pixels.                      |

--- a/sidebars.js
+++ b/sidebars.js
@@ -198,6 +198,7 @@ module.exports = {
             items: [
                 "guides/initialization",
                 "guides/configuration",
+                "guides/working_with_server",
                 "guides/localization",
                 "guides/stylization",
                 "guides/typescript_support"

--- a/sidebars.js
+++ b/sidebars.js
@@ -204,6 +204,7 @@ module.exports = {
             items: [
                 "guides/initialization",
                 "guides/configuration",
+                "guides/working_with_server",
                 "guides/mentions_and_tags",
                 "guides/localization",
                 "guides/stylization",


### PR DESCRIPTION
what's changed:

- new guides/working_with_server.md covering the image upload contract: default inline-base64 behavior, POST request shape (multipart, field name "upload"), expected JSON response (status/value/width/height), how the returned URL is reused as the <img src>, and a demo backend URL to try the flow against
- sidebar entry under Guides, after Configuration
- cross-links from imageUploadUrl API page and the "Configure the image upload URL" section in configuration.md

to do:

- I haven't run the new article skills against the article. It's correct factually, but may not comply with the skills.