### PR TITLE
[add] document insertValue() method

### DIFF
--- a/docs/api/methods/insert-value.md
+++ b/docs/api/methods/insert-value.md
@@ -1,0 +1,45 @@
+---
+sidebar_label: insertValue()
+title: insertValue Method
+description: You can learn about the insertValue method in the documentation of the DHTMLX JavaScript RichText library. Browse developer guides and API reference, try out code examples and live demos, and download a free 30-day evaluation version of DHTMLX RichText.
+---
+
+# insertValue()
+
+### Description
+
+@short: Inserts a value at the current cursor position or replaces the selected text
+
+### Usage
+
+~~~jsx {}
+insertValue: (value: string, encoder?: any): void;
+~~~
+
+### Parameters
+
+- `value` - (required) a value to be inserted into the RichText at the current cursor position. If a selection is active, the selection is replaced with the new value
+- `encoder` - (optional) a parser used to decode the inserted value from a custom format. The following formats are available: `html` (default), `text`, and `markdown`
+
+You can get the required encoder in the following way:
+
+```jsx
+const fromTextEncoder = richtext.text.fromText;             // text encoder
+const fromHTMLEncoder = richtext.html.fromHTML;             // html encoder
+const fromMarkdownEncoder = richtext.markdown.fromMarkdown; // markdown encoder
+```
+
+### Example
+
+~~~jsx {6}
+const editor = new richtext.Richtext("#root", {
+    // configuration properties
+});
+
+// inserts an HTML link with custom attributes at the cursor position
+editor.insertValue("<a href=\"https://example.com\" title=\"Example\">link</a>");
+~~~
+
+The inserted content is added as a single history entry and can be reverted with one **Undo** step.
+
+**Change log:** The method was added in v2.1

--- a/docs/api/methods/insert-value.md
+++ b/docs/api/methods/insert-value.md
@@ -8,7 +8,7 @@ description: You can learn about the insertValue method in the documentation of 
 
 ### Description
 
-@short: Inserts a value at the current cursor position or replaces the selected text
+@short: Inserts text, Markdown, or HTML content at the current cursor position or replaces the selected text
 
 ### Usage
 
@@ -19,7 +19,7 @@ insertValue: (value: string, encoder?: any): void;
 ### Parameters
 
 - `value` - (required) a value to be inserted into the RichText at the current cursor position. If a selection is active, the selection is replaced with the new value
-- `encoder` - (optional) a parser used to decode the inserted value from a custom format. The following formats are available: `html` (default), `text`, and `markdown`
+- `encoder` - (optional) a parser used to decode the inserted value. The following formats are available: `html` (default), `text`, and `markdown`
 
 You can get the required encoder in the following way:
 

--- a/docs/api/overview/main_overview.md
+++ b/docs/api/overview/main_overview.md
@@ -25,6 +25,7 @@ new richtext.RichText("#root", {
 | ----------------------------------------------|-------------------------------------------|
 | [](api/methods/get-value.md)                   | @getshort(api/methods/get-value.md)        |
 | [](api/methods/set-value.md)                   | @getshort(api/methods/set-value.md)        |
+| [](api/methods/insert-value.md)                | @getshort(api/methods/insert-value.md)     |
 | [](api/methods/set-config.md)                  | @getshort(api/methods/set-config.md)       |
 | [](api/methods/set-locale.md)                  | @getshort(api/methods/set-locale.md)       |
 | [](api/methods/destructor.md)                  | @getshort(api/methods/destructor.md)       |

--- a/docs/api/overview/methods_overview.md
+++ b/docs/api/overview/methods_overview.md
@@ -14,5 +14,6 @@ Use this reference to quickly navigate to detailed descriptions of each method, 
 | [](api/methods/destructor.md)                           | @getshort(api/methods/destructor.md)       |
 | [](api/methods/get-value.md)                            | @getshort(api/methods/get-value.md)        |
 | [](api/methods/set-value.md)                            | @getshort(api/methods/set-value.md)        |
+| [](api/methods/insert-value.md)                         | @getshort(api/methods/insert-value.md)     |
 | [](api/methods/set-config.md)                           | @getshort(api/methods/set-config.md)       |
 | [](api/methods/set-locale.md)                           | @getshort(api/methods/set-locale.md)       |

--- a/sidebars.js
+++ b/sidebars.js
@@ -49,6 +49,7 @@ module.exports = {
                         "api/methods/destructor",
                         "api/methods/get-value",
                         "api/methods/set-value",
+                        "api/methods/insert-value",
                         "api/methods/set-config",
                         "api/methods/set-locale"
                     ]


### PR DESCRIPTION
- new article docs/api/methods/insert-value.md covering description, parameters (value, optional encoder), encoder snippet (text/html/markdown), example and v2.1 change log
- register the method in sidebars.js and in main_overview.md / methods_overview.md tables