### PR TITLE
[update] note paste and drag-and-drop as image upload sources

### DIFF
--- a/docs/api/config/image-upload-url.md
+++ b/docs/api/config/image-upload-url.md
@@ -8,7 +8,7 @@ description: You can learn about the imageUploadUrl config in the documentation 
 
 ### Description
 
-@short: Optional. Specifies the URL which will be used for image upload
+@short: Optional. Specifies the URL which will be used for image upload (from the toolbar, menubar, clipboard paste, or drag-and-drop)
 
 ### Usage
 

--- a/docs/api/events/insert-image.md
+++ b/docs/api/events/insert-image.md
@@ -8,7 +8,7 @@ description: You can learn about the insert-image event in the documentation of 
 
 ### Description
 
-@short: Fires when inserting image
+@short: Fires when inserting an image (via the toolbar, menubar, clipboard paste, or drag-and-drop)
 
 ### Usage
 

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -240,7 +240,7 @@ new richtext.Richtext("#root", {
 
 ## Configure the image upload URL
 
-Pass a URL to the [`imageUploadUrl`](api/config/image-upload-url.md) property to set the server endpoint for toolbar image uploads:
+Pass a URL to the [`imageUploadUrl`](api/config/image-upload-url.md) property to set the server endpoint for image uploads triggered from the toolbar, menubar, clipboard paste, or drag-and-drop:
 
 ~~~jsx {2}
 new richtext.Richtext("#root", {


### PR DESCRIPTION
- image-upload-url.md @short and configuration guide now state that image uploads can be triggered from the toolbar, menubar, clipboard paste, or drag-and-drop, not just the toolbar
- insert-image.md @short updated to match