### PR TITLE
[fix] reword toggle-list event description

### DIFF
--- a/docs/api/events/toggle-list.md
+++ b/docs/api/events/toggle-list.md
@@ -8,7 +8,7 @@ description: You can learn about the toggle-list event in the documentation of t
 
 ### Description
 
-@short: Fires when the user toggles a list on the selected blocks
+@short: Fires when a user toggles a list on the selected blocks
 
 The `toggle-list` event powers the context-aware bulleted/numbered list buttons. Instead of inserting a new list, the event inspects the current selection and picks one of four behaviors automatically:
 

--- a/docs/news/whats_new.md
+++ b/docs/news/whats_new.md
@@ -18,7 +18,7 @@ Released on May 28, 2026
 
 #### New events
 
-- [`toggle-list`](api/events/toggle-list.md) — Fires when toggling a list on the selected blocks
+- [`toggle-list`](api/events/toggle-list.md) — Fires when a user toggles a list on the selected blocks
 
 ### Fixes
 


### PR DESCRIPTION
- use "a user toggles" wording for consistency
- align whats_new entry with event short description